### PR TITLE
トップページレイアウト修正

### DIFF
--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -1,134 +1,76 @@
 .top-title {
-  text-align: center; 
-  margin-top: 80px;
-  
+  text-align: center;
 }
 
 .top-title h1 {
-  font-size: 110px;
-  text-align:center;
-  line-height:0.95em;
+  font-size: calc(5.95vw + 2rem);
+  line-height: 0.95em;
   font-family: cursive;
   color: transparent;
   background: repeating-linear-gradient(0deg, #B67B03 0.1em, #DAAF08 0.2em, #FEE9A0 0.3em, #DAAF08 0.4em, #B67B03 0.5em); 
   -webkit-background-clip: text;
-  -webkit-box-reflect: below -0.25em -webkit-gradient(linear, left bottom, left top, from(rgba(255, 255, 255, .6)), to(transparent));
   padding-top: 50px;
+  padding-bottom: 50px;
+  margin-top: 80px;
 }
 
 body {
-  background-color: #840000f1;
+  background-color: #7f0909f1;
 }
 
-
-.sav-title h3 {
-    text-align: center;
-    color: rgb(255, 255, 255);
-    position: absolute;
-    top:  47%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    white-space: nowrap;
+p {
+  font-size: calc(0.85vw + 1rem);
+  text-align: center;
+  color: rgb(255, 255, 255);
 }
 
+.nav-link {
+  color: rgb(255, 255, 255);
+}
+
+.nav-link:hover {
+  color: rgb(255, 255, 255);
+  box-shadow: none;
+  transform: translateY(5px);
+  text-decoration: underline;
+}
 
 .links {
   display: flex;
   flex-direction: column;
   align-items: center;
-  position: absolute;
-  top:  70%;
-  left: 50%;
-  transform: translate(-50%, -50%);
 }
 
 .link {
-  text-decoration: none;
   color: #ffffff;
   margin-top: 50px;
+  text-decoration: none;
 }
 
+.link:hover {
+  color: #ffffff;
+  box-shadow: none;
+  text-decoration: underline;
+  transform: translateY(5px);
+}
 
 .bg-light {
-    background-color: #840000f1 !important;
+    background-color: #000000f1 !important;
 }
 
+.btn {
+  background-color: rgb(255, 242, 132);
+  color: rgb(74, 57, 57);
+  border-radius: 100vh;
+}
 
-  .btn {
-    background-color: rgb(253, 202, 210);
-    color: rgb(0, 0, 0);
-    border-radius: 100vh;
-  }
+.btn:hover {
+  color: rgb(160, 160, 160);
+  box-shadow: none;
+  transform: translateY(5px);
+}
 
-  .btn:hover {
-    box-shadow: none;
-    transform: translateY(5px);
-  }
-
-  .btn1 {
-    background-color: rgba(239, 232, 62, 1);
-    color: black;
-  }
-
-  .btn2 {
-    background-color: rgb(250, 0, 0);
-    color: black;
-  }
-  
-  .nav-link {
-    color: rgb(255, 255, 255);
-  }
-
-  /* 映画の記録を作成するタイトルlink */
-  .custom-large-text {
-    font-size: 30px; 
-    text-shadow:
-    -1px -1px 0 rgb(0, 0, 0), /* 左上に1pxずつずらして黒色の縁取りを作成 */
-    1px -1px 0 rgb(255, 247, 0),
-    -1px 1px 0 rgb(0, 0, 0),
-    1px 1px 0 rgb(255, 247, 0);
-  }
-
-
-  .navbar-brand {
-    color: rgba(239, 232, 62, 1);
-    font-family: cursive;
-    font-size: 20px;
-  }
-
-
-  .stars {
-    position: relative;
-    width: 100%; /* 星空の横幅 */
-    height: 110vh; /* 星空の縦幅 */
-    background-image: linear-gradient(0deg, #d63434, #810000, #080f1c); /* 星空の背景色 */
-    overflow: hidden; /* 星が枠外にはみ出すのを防ぐ */
-  }
-  
-  /* 星のスタイル */
-  .star {
-    position: absolute;
-    display: block;
-    background-color: #fff; /* 星の色 */
-    border-radius: 50%;
-    box-shadow: 0 0 4px 2px rgba(#fff, 0.2); /* 星の影 */
-    opacity: 0;
-    animation: twinkle 5s infinite;
-  }
-  
-  /* 星がキラキラ光るアニメーション */
-  @keyframes twinkle {
-    0% {
-      opacity: 0;
-    }
-  
-    50% {
-      transform: scale(1.1);
-      opacity: 1;
-    }
-  
-    100% {
-      opacity: 0;
-      transform: scale(1);
-    }
-  }
+.btn2 {
+  background-color: rgb(255, 255, 255);
+  color: black;
+}

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,7 +25,7 @@
       </li>
       <%= link_to t('movierecords.likes.title'), likes_movierecords_path, class: 'nav-link' %>
       </li>
-      <%= button_to t('defaults.logout'), logout_path, class: 'btn btn-pink', method: :delete %>
+      <%= button_to t('defaults.logout'), logout_path, class: 'btn', method: :delete %>
       </li>
       </ul>
     </div>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -1,21 +1,19 @@
-<div class="stars">
 <div class="container">
     <div class='top-title'>
       <h1>My Cinema Record</h1>
     </div>
-    <div class='sav-title'>
-      <h3>忘れずに観た映画を記録、ツイートし皆に知ってもらおう。</h3>
-    </div>
-    <div class="links">
-      <%= link_to "ユーザーの観た映画記録を見る", movierecords_path, class: 'link' %>
-      <%= link_to movie_information_path, class: 'link' do %>
-      <i class="fa-solid fa-circle-info fa-flip" style="color: #f2f2f2;"></i>映画を観に行く前情報
-      <% end %>
-      <%= link_to rankings_path, class: 'link' do %>
-        ユーザー達の観た映画記録数、ランキング<i class='fas fa-crown' style='color:#f0d000'></i>
-        <% end %>
-      <%= link_to movies_search_path, class: 'link' do %>
-        映画検索＆上映されている映画、動画配信サイトで観れる最新映画<i class="fa-regular fa-star fa-spin" style="color: #fff700;"></i>
-      <% end %>
-      </div>
+    <p class='sav-title'>
+      忘れずに観た映画を記録、ツイートし皆に知ってもらおう。</p>
+    <div class="links mb-5">
+    <%= link_to "ユーザーの観た映画記録を見る", movierecords_path, class: 'link' %>
+    <%= link_to movie_information_path, class: 'link' do %>
+      映画を観に行く前情報<i class="fa-solid fa-circle-info fa-flip" style="color: #f2f2f2;"></i>
+    <% end %>
+    <%= link_to rankings_path, class: 'link' do %>
+      ユーザー達の観た映画記録数、ランキング<i class='fas fa-crown' style='color:#f0d000'></i>
+    <% end %>
+    <%= link_to movies_search_path, class: 'link' do %>
+      映画検索＆上映されている映画、動画配信サイトで観れる最新映画<i class="fa-regular fa-star fa-spin" style="color: #fff700;"></i>
+    <% end %>
   </div>
+</div>


### PR DESCRIPTION
トップページのレイアウトを全体的に修正。
画面を縮小した際、文字が重なるのを修正、及び文字間隔修正。
星空削除。
ヘッダーを黒色。
ボタンを薄黄色の文字を黒色、カーソルが置かれると文字のみになりグレー色。
タイトル文字を反射文字なしに。
リンクをわかりやすくカーソルが置かれると文字の色白色のまま下に線が出る様に。
