### PR TITLE
fix:トップページ・ヘッダー修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,12 @@
 @import "label";
 @import "twitter";
 @import "movierecord";
+
+.custom-toggler.navbar-toggler .navbar-toggler-icon {
+    background-color: #ffffff;
+}
+
+.custom-toggler {
+    border: 2px solid #f4f4f4; /* 枠線の幅と色を設定 */
+    border-radius: 5px; /* 枠線の角を丸くする場合 */
+}

--- a/app/assets/stylesheets/top.scss
+++ b/app/assets/stylesheets/top.scss
@@ -14,14 +14,15 @@
   margin-top: 80px;
 }
 
-body {
-  background-color: #7f0909f1;
-}
-
-p {
+.sav-title{
   font-size: calc(0.85vw + 1rem);
   text-align: center;
   color: rgb(255, 255, 255);
+  font-weight: bold;
+}
+
+body {
+  background-color: #7f0909f1;
 }
 
 .nav-link {
@@ -71,6 +72,6 @@ p {
 }
 
 .btn2 {
-  background-color: rgb(255, 255, 255);
+  background-color: rgb(255, 0, 0);
   color: black;
 }

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -4,15 +4,15 @@
   <%= image_tag 'top.png', size: '360x60' %>
 <% end %>
       
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler custom-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
 
     <div class='collapse navbar-collapse justify-content-end' id='navbarSupportedContent'>
       <ul class='navbar-nav ml-auto main-nav align-items-center'>
         <li class="nav-item">
-            <%= link_to t('defaults.sign_up'), new_user_path, class: 'btn btn-pink' %>
-            <%= link_to t('defaults.login'), login_path, class: 'btn btn-pink' %>
+            <%= link_to t('defaults.sign_up'), new_user_path, class: 'btn' %>
+            <%= link_to t('defaults.login'), login_path, class: 'btn' %>
         </li>
       </ul>
     </div> 

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -2,8 +2,9 @@
     <div class='top-title'>
       <h1>My Cinema Record</h1>
     </div>
-    <p class='sav-title'>
-      忘れずに観た映画を記録、ツイートし皆に知ってもらおう。</p>
+    <div class='sav-title'>
+      忘れずに観た映画を記録、ツイートし皆に知ってもらおう!!
+    </div>
     <div class="links mb-5">
     <%= link_to "ユーザーの観た映画記録を見る", movierecords_path, class: 'link' %>
     <%= link_to movie_information_path, class: 'link' do %>


### PR DESCRIPTION
トップページのサブタイトル部分を太文字に変更。
ヘッダーのハンバーガーメニューを見やすく修正。 